### PR TITLE
fix bug when parse fortran  style exponent number

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -998,7 +998,7 @@ class Parser(object):
             s = r'\d+\.\d+'
             self._type_conversions[group] = lambda s, m: Decimal(s)
         elif type == 'e':
-            s = r'\d+\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF'
+            s = r'\d*\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF'
             self._type_conversions[group] = lambda s, m: float(s)
         elif type == 'g':
             s = r'\d+(\.\d+)?([eE][-+]?\d+)?|nan|NAN|[-+]?inf|[-+]?INF'


### PR DESCRIPTION
example: '.196937E-02'